### PR TITLE
Protocol handler stub cleanup

### DIFF
--- a/luasrc/model/network/proto_commotion.lua
+++ b/luasrc/model/network/proto_commotion.lua
@@ -1,7 +1,7 @@
 --[[
-LuCI - Network model - 3G, PPP, PPtP, PPPoE and PPPoA protocol extension
+LuCI - Network model - Commotion protocol extension
 
-Copyright 2011 Jo-Philipp Wich <xm@subsignal.org>
+Copyright 2013 Josh King <jking@chambana.net>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Removing a lot of unnecessary stuff from proto_commotion.lua, particularly a bunch of functions that screw up the display of interfaces in the admin wifi page.
