### PR TITLE
added dhcp timeout form field to meshconfig cbi page

### DIFF
--- a/luasrc/model/cbi/commotion/meshconfig.lua
+++ b/luasrc/model/cbi/commotion/meshconfig.lua
@@ -55,4 +55,10 @@ else
    end
 end
 
-return m
+m2 = Map("commotiond")                                                                                                                         
+node = m2:section(TypedSection, "node", translate("Settings specific to this node"))
+node.anonymous = true
+node.optional = true
+node:option(Value, "dhcp_timeout", "DHCP Timeout", "How many seconds to wait on boot for a DHCP lease from the gateway")
+
+return m, m2


### PR DESCRIPTION
This should be tested in conjunction with the commotiond dhcp-timeout pull request: https://github.com/opentechinstitute/commotiond/pull/29

to test:
- the main admin page should have an option at the bottom for the DHCP timeout...change it, and make sure it sticks.
