### PR TITLE
Added validation for fqdns instead of just hostnames

### DIFF
--- a/luasrc/commotion_helpers.lua
+++ b/luasrc/commotion_helpers.lua
@@ -122,8 +122,6 @@ function is_email(email)
    return tostring(email):match("[A-Za-z0-9%.%%%+%-]+@[A-Za-z0-9%.%%%+%-]+%.%w%w%w?%w?")
 end
 
-
-
 function is_hostname(str)
 --alphanumeric and hyphen Less than 63 chars
 --cannot start or end with a hyphen
@@ -131,6 +129,14 @@ function is_hostname(str)
 	  return tostring(str):match("^%w[%w%-]*%w$")
    else
 	  return nil
+   end
+end
+
+function is_fqdn(str)
+   if #tostring(str) < 255 then
+	return tostring(str):match("[A-Za-z0-9%.%%%+%-]+%.%w%w%w?%w?")
+   else
+	return nil
    end
 end
 


### PR DESCRIPTION
is_fqdn should accept only alphanumeric characters, periods (.), and hyphens (-). Total length must be less than 255 characters.

Can be tested by submitting an overly long or invalid hostname through luci-commotion-dash
