### PR TITLE
Reworked quick fqdn check

### DIFF
--- a/luasrc/commotion_helpers.lua
+++ b/luasrc/commotion_helpers.lua
@@ -133,8 +133,11 @@ function is_hostname(str)
 end
 
 function is_fqdn(str)
+-- alphanumeric and hyphen less than 255 chars
+-- each label must be less than 63 chars
    if #tostring(str) < 255 then
-	return tostring(str):match("[A-Za-z0-9%.%%%+%-]+%.%w%w%w?%w?")
+	-- Should check that each label is < 63 chars --
+	return tostring(str):match("^[%w%.%-]+$")
    else
 	return nil
    end


### PR DESCRIPTION
Quick check that a submitted fqdn uses valid characters and is less than 255 characters overall. Should still be rewritten to also check that each dot-separated segment is less than 63 characters.

To test, submit 3 domains through luci-commotion-dash: www.commotionwireless.net, www.commotionwireless.net:1337, and www.comm%00tionwireless.net. Only the first should be accepted.
