### PR TITLE
Require sysauth cookies to be sent via web over SSL only

### DIFF
--- a/files/etc/uci-defaults/luci-proto-commotion
+++ b/files/etc/uci-defaults/luci-proto-commotion
@@ -3,6 +3,9 @@
 [ -f "/usr/bin/patch" ] && { \
   cd /usr/lib/lua/luci/model/cbi/admin_network/
   patch -p0 < /usr/share/commotion/patches/wifi.lua.patch
+
+  cd /usr/lib/lua/luci/
+  patch -p0 < /usr/share/commotion/patches/dispatcher-cookies.patch
 }
 
 rm -f /tmp/luci-indexcache

--- a/files/usr/share/commotion/patches/dispatcher-cookies.patch
+++ b/files/usr/share/commotion/patches/dispatcher-cookies.patch
@@ -1,0 +1,11 @@
+--- dispatcher.lua	2013-10-11 14:46:09.553407012 -0400
++++ dispatcher-cookies.lua	2013-10-11 14:49:51.833402451 -0400
+@@ -382,7 +382,7 @@
+ 						})
+ 						ctx.urltoken.stok = token
+ 					end
+-					luci.http.header("Set-Cookie", "sysauth=" .. sid.."; path="..build_url())
++					luci.http.header("Set-Cookie", "sysauth=" .. sid.."; path="..build_url() .. "; secure; HttpOnly;")
+ 					ctx.authsession = sid
+ 					ctx.authuser = user
+ 				end


### PR DESCRIPTION
Addresses commotion-openwrt issue #33 and #34.

Quick test: Visit any admin page and use the Cookies tab in Firebug to confirm that the sysauth cookie contains both the httpOnly and Secure flags.

<!---
@huboard:{"order":11.625}
-->
