### PR TITLE
Improved logic of uploader function

### DIFF
--- a/luasrc/controller/commotion/meshprofile.lua
+++ b/luasrc/controller/commotion/meshprofile.lua
@@ -179,11 +179,11 @@ function up()
    local overwrite = values["overwrite"]
    
    local ul = values["config"]
-   if ul ~= '' and ul ~= nil then
-	  --TODO add logging to checkfile to identify why it does not work
-	  file = "/tmp/" .. ul
-	  error = checkFile(file)
-   end
+   
+   --TODO add logging to checkfile to identify why it does not work
+   file = "/tmp/" .. ul
+   error = checkFile(file)
+   
    if error ~= nil then
 	  main(error)
 	  


### PR DESCRIPTION
Removed unnecessary if condition. Now all uploads are run through the checkFile function, which will catch empty uploads.

To check:
1) Navigate to mesh profile page
2) Click "upload" (do NOT attach a file first)
3) The page should refresh with a warning that says "There does not seem to be a file here"

Rinse and repeat.
