### PR TITLE
Fixed uci get for 5ghz devices

### DIFF
--- a/luasrc/model/cbi/commotion/meshconfig.lua
+++ b/luasrc/model/cbi/commotion/meshconfig.lua
@@ -15,21 +15,6 @@ local uci = require "luci.model.uci".cursor()
 local sys = require "luci.sys"
 local util = require "luci.util"
 
-function log(msg)
-if (type(msg) == "table") then
-for key, val in pairs(msg) do
-log('{')                                                                         
-log(key)
-log(':')
-log(val)
-log('}')
-end
-else
-luci.sys.exec("logger -t luci \"" .. tostring(msg) .. '"')
-end
-end
-
-
 m = Map("wireless", translate("Configuration"), translate("This configuration wizard will assist you in setting up your router for a Commotion network."))
 
 sctAP = m:section(NamedSection, "quickstartAP", "wifi-iface", translate("Access Point"))


### PR DESCRIPTION
Addresses #25
To test (for ubiquiti devices):
1. Set radio0 hwmode to 11na in /etc/config/wireless
2. Load Admin > Commotion > Mesh Configuration (Manual) page. Channel configuration dropdown menu should display 5ghz options.

<!---
@huboard:{"order":6.125}
-->
