### PR TITLE
Fixed shared mesh keychain upload.

### DIFF
--- a/luasrc/model/cbi/commotion/security_smk.lua
+++ b/luasrc/model/cbi/commotion/security_smk.lua
@@ -1,3 +1,4 @@
+
 --[[
    Copyright (C) 2013 Seamus Tuohy
 
@@ -96,7 +97,7 @@ function set_commotion()
 				  if s.mode == 'adhoc' then
 					 if uci:get("network", s.network, "proto") == "commotion" then
 						local profile = uci:get("network", s.network, "profile")
-						cnet.commotion_set(profile, {mdp_keyring="/etc/commotion/keys.d/mdp/", mdp_sid=sid, serval='true'})
+						cnet.commotion_set(profile, {mdp_keyring="/etc/commotion/keys.d/mdp/serval.keyring", mdp_sid=sid, serval='true'})
 						cnet.commotion_set(profile)
 					 end
 				  end


### PR DESCRIPTION
fixed bug that caused uploaded shared mesh keychains to set the incorrect value in the commotion profile. This caused olsrd to crash.

This will fix issues with uploading shared mesh keychains.

To test 
- build image with this branch
- upload a working key from another node
- check that olsrd is running
- check that the node is sending out olsrd traffic control messages that are signed
