### PR TITLE
made it so that the encryption value is not removed upon deletion and in...

### DIFF
--- a/luasrc/model/cbi/commotion/security_pass.lua
+++ b/luasrc/model/cbi/commotion/security_pass.lua
@@ -66,7 +66,7 @@ function pw_sec_opt(pw_s, iface)
    enc = pw_s:option(Flag, "encryption", translate("Require a Password?"), translate("When people connect to this access point, should a password be required?"))
    enc.disabled = "none"
    enc.enabled = "psk2"
-   enc.rmempty = true
+   enc.rmempty = false
    enc.default = enc.disabled --default must == disabled value for rmempty to work
    
    --Make enc flag actually check for section.changed and set that flag for the confirmation page to work


### PR DESCRIPTION
...stead is set to none so that when network restarts commotiond will not fill in the value.

See issue # 142 https://github.com/opentechinstitute/luci-commotion/issues/142

To test remove encryption using the security menu and then restart networking. If this is successful encryption will still be disabled for the interface. If unsuccessful then encryption will be on for the interface and the password will be set to the commotion default.

<!---
@huboard:{"order":81.375}
-->
