### PR TITLE
Issue #166 Fix.

### DIFF
--- a/luasrc/model/cbi/commotion/security_pass.lua
+++ b/luasrc/model/cbi/commotion/security_pass.lua
@@ -148,7 +148,7 @@ if #mesh_ifaces > 1 then
 	  local meshPW = m:section(NamedSection, x.name, "wifi-iface", x.name, pw_text)
 	  meshPW = pw_sec_opt(meshPW, x, 'adhoc')
    end
-else
+elseif  #mesh_ifaces == 1 then
    local meshPW = m:section(NamedSection, mesh_ifaces[1].name, "wifi-iface", mesh_ifaces[1].name, pw_text)
    meshPW = pw_sec_opt(meshPW, mesh_ifaces[1], 'adhoc')
 end


### PR DESCRIPTION
Made single adhoc interface condition explicit about requirement for a "single" adhoc interface. It had been falling back to a state that assumed at least one ad-hoc interface existed without asserting it.

per: https://github.com/opentechinstitute/luci-commotion/issues/166
@areynold 

To test this pull request. 
- Create a build with this branch of luci-commotion
- Configure node though setup wizard
- Go to the menu Basic Configuration --> Mesh Network 
- Click on the delete button of the mesh interface
- Click save
- Apply the changes
- Go to Security --> Passwords
- If the interface errors out this patch did not work.
