### PR TITLE
Fix for Issue 143. Secondary check to ensure setup wizard is disabled.

### DIFF
--- a/luasrc/controller/commotion/basic_config.lua
+++ b/luasrc/controller/commotion/basic_config.lua
@@ -31,8 +31,7 @@ local db = require "luci.commotion.debugger"
 
 function index()
    local SW = require "luci.commotion.setup_wizard"
-
-   entry({"admin", "commotion"}, alias("admin", "commotion", "status"), translate("Commotion"), 20)
+   entry({"admin", "commotion"}, call("setup_wiz_close"), translate("Commotion"), 20)
 
    local page  = node()
    page.lock   = true
@@ -101,6 +100,22 @@ function index()
 	  entry({"admin", "commotion", "basic", "addtl_net_ifaces"}, cbi("commotion/basic_ani", {hideapplybtn=true, hideresetbtn=true}), translate("Additional Network Interfaces"), 60)
    end
 end
+
+function setup_wiz_close()
+   local SW = require "luci.commotion.setup_wizard"
+   local disp = require "luci.dispatcher"
+   local http = require "luci.http"
+   
+   if SW.status() then
+	  local uci = require "luci.model.uci".cursor()
+	  uci:set("setup_wizard", "settings", "enabled", "0")
+	  uci:save("setup_wizard")
+	  uci:commit("setup_wizard")
+   end
+   local stat = disp.build_url("admin", "commotion", "status")
+   http.redirect(stat)
+end
+
 
 function advanced()
    local uci = require "luci.model.uci".cursor()


### PR DESCRIPTION
Modified the root level node that the login page redirects to. It is now a function that first checks for, and if on removes, the setup wizard flag. After the check the function then redirects to the default status page.
https://github.com/opentechinstitute/luci-commotion/issues/143

Testing Instructions for this pull request. 

Test # 1
- Flash a router with this branch of luci-commotion
- During setup wizard, at any point, click on the advanced button in the footer
- Once logged in, there should be a "basic configuration" side menu.
- If the basic config menu is missing then the patch did not work.

Test # 2
- Reflash router to its default state (Or just change the enabled flag in /etc/config/setup_wizard to "1"
- Complete the setup wizard. 
- When the node is running its "applying" animation click the finish button as soon as possible.
- This will skip the old setup wizard check and take you to the login page. 
- Once logged in, there should be a "basic configuration" side menu.
- If the basic config menu is missing then the patch did not work.
