### PR TITLE
Reject ssh changes with invalid root password

### DIFF
--- a/files/etc/uci-defaults/luci-mod-commotion
+++ b/files/etc/uci-defaults/luci-mod-commotion
@@ -14,7 +14,7 @@ cp -f /usr/share/commotion/files/olsr-viz.sh /www/cgi-bin/olsr-viz.sh
 
 [ -f "/usr/bin/patch" ] && { \
   cd /usr/lib/lua/luci/controller/admin/
-  patch -p0 < /usr/share/commotion/patches/system.oldpasswd.patch
+  patch -p1 < /usr/share/commotion/patches/system.oldpasswd.patch
 
   cd /usr/lib/lua/luci/model/cbi/admin_system/
   patch -p1 < /usr/share/commotion/patches/admin.oldpasswd.patch

--- a/files/usr/share/commotion/patches/admin.oldpasswd.patch
+++ b/files/usr/share/commotion/patches/admin.oldpasswd.patch
@@ -1,13 +1,13 @@
---- admin.lua	2014-02-21 16:33:40.760712034 -0500
-+++ admin.new.lua	2014-02-21 16:38:31.456701514 -0500
-@@ -14,14 +14,35 @@
+diff --git a/admin.lua b/admin.lua
+index 61f0141..28f4b78 100644
+--- a/admin.lua
++++ b/admin.lua
+@@ -14,14 +14,35 @@ $Id: admin.lua 8153 2012-01-06 16:42:02Z jow $
  ]]--
  
  local fs = require "nixio.fs"
 +local formvalue = require "luci.http".formvalue
- 
--m = Map("system", translate("Router Password"),
--	translate("Changes the administrator password for accessing the device"))
++
 +m = Map("system", translate("System Access"),
 +	translate("System functions related to system access"))
 +local v0 = true -- track password success across maps
@@ -30,9 +30,11 @@
 +	end
 +end
  
--s = m:section(TypedSection, "_dummy", "")
+-m = Map("system", translate("Router Password"),
 +s = m:section(TypedSection, "_dummy", translate("Router Password"),
-+	translate("Changes the administrator password for accessing the device"))
+ 	translate("Changes the administrator password for accessing the device"))
+-
+-s = m:section(TypedSection, "_dummy", "")
  s.addremove = false
  s.anonymous = true
 -
@@ -40,7 +42,7 @@
  pw1 = s:option(Value, "pw1", translate("Password"))
  pw1.password = true
  
-@@ -32,23 +53,38 @@
+@@ -32,23 +53,38 @@ function s.cfgsections()
  	return { "_pass" }
  end
  
@@ -91,7 +93,7 @@
  
  if fs.access("/etc/config/dropbear") then
  
-@@ -120,7 +156,7 @@
+@@ -120,7 +156,7 @@ function keys.cfgvalue()
  end
  
  function keys.write(self, section, value)


### PR DESCRIPTION
Closes #155 

To test:
1. Open Administration > Advanced > System > Administration in a web browser
2. SSH into the node and run `uci show dropbear`
3. Using an incorrect/blank root password, change a number of settings on the page, including ssh keys.
4. Click Save, then run `uci show dropbear` from the command line. The settings should not have changed. If you added an ssh key, it should not have been added to /etc/dropbear/authorized_keys.
5. Repeat using an incorrect root password and Save & Apply instead of Save. Your settings should not appear in /etc/config/dropbear.
6. Enter the correct root password and repeat. Your new settings should have been saved.
