### PR TITLE
removed return statements from init calls

### DIFF
--- a/files/etc/init.d/ucidog
+++ b/files/etc/init.d/ucidog
@@ -35,10 +35,10 @@ reload() {
 	#disable/enable nodogsplash
 	local enable=$(uci_get nodogsplash settings enable)
 	echo "$enable"
-	if [ "$enable" == '1' ]; then #this might come back as a string and not as a intiger. Check and fix that.
-		/etc/init.d/nodogsplash enable  || return 0
-		/etc/init.d/nodogsplash start || return 0
+	if [ "$enable" == '1' ]; then #this might come back as a string and not as a integer. Check and fix that.
+		/etc/init.d/nodogsplash enable
+		/etc/init.d/nodogsplash start
 	else
-		/etc/init.d/nodogsplash disable  || return 0
+		/etc/init.d/nodogsplash disable
 	fi
 }


### PR DESCRIPTION
Fixes #184 

To test:
1. In your browser, go to Admin > Client Controls and change the Time Until Welcome Page is Shown. 
2. Click Save, then Save & Apply.
3. SSH in and run `ndsctl status`. If you see actual nodogsplash data, the fix worked. If the fix didn't work you will see `ndsctl: nodogsplash probably not started (Error: Connection refused)`.
