### PR TITLE
Moves system level setting of the hostname to the "apply" stage of luci value settings

### DIFF
--- a/files/etc/init.d/hostname
+++ b/files/etc/init.d/hostname
@@ -8,9 +8,9 @@ START=19
 STOP=91
 
 reload() {
-	local host_name=$(uci_get system system hostname)
+	local host_name=$(uci_get system @system[0] hostname)
 	len=${#host_name}
-	if [[ $len > 0 ]]; then
+	if [[ "$len" -gt 0 ]]; then
 		echo $host_name > /proc/sys/kernel/hostname
 	fi
 	

--- a/files/etc/uci-defaults/luci-setup-wizard
+++ b/files/etc/uci-defaults/luci-setup-wizard
@@ -9,6 +9,9 @@ uci add_list ucitrack.@system[0].affects=avahi_daemon
 uci add ucitrack avahi_daemon
 uci set ucitrack.@avahi_daemon[0].init=avahi-daemon
 uci add_list ucitrack.@setup_wizard[0].affects=nodogsplash
+uci add ucitrack hostname
+uci set ucitrack.@hostname[0].init=hostname
+uci add_list ucitrack.@system[0].affects=hostname
 uci commit ucitrack
 
 #setup sysupgrade saves

--- a/luasrc/model/cbi/commotion/basic_ns.lua
+++ b/luasrc/model/cbi/commotion/basic_ns.lua
@@ -59,7 +59,6 @@ function hname.write(self, section, value)
 	  return true
    else
 	  local new_hn = value.."-"..string.sub(node_id, 1, 10)
-	  luci.sys.hostname(new_hn)
 	  return self.map:set(section, self.option, new_hn)
    end
 end


### PR DESCRIPTION
Per Issue #180 this pull request modifies the way hostnames are added to the system by pushing all system-level manipulation of the hostname into a init.d script. 

To Test: 
1) Flash a node with this branch included
2) Connect to node and click "setup wizard"
3) Change the host-name to one of your choosing on the first page
4) On the next page the hostname field in the header should still read "commotion"
5) On the "Save and Apply" page click the "Start Over" button
6) If the hostname changes should now be reverted 
7) Add a new hostname
8) On the "Save and Apply" page click the "Save and Apply" button
9) Log into the administration menu
10) In the header should state the new hostname you added as your hostname.
