### PR TITLE
Fix for issue #172

### DIFF
--- a/luasrc/model/cbi/commotion/security_smk.lua
+++ b/luasrc/model/cbi/commotion/security_smk.lua
@@ -46,6 +46,7 @@ end
 function s.create(self, section)
    sys.exec("rm /etc/commotion/keys.d/mdp/serval.keyring")
    set_commotion()
+   s.fields.sid.default = get_sid()
    return AbstractSection.create(self, section)
 end
 
@@ -89,6 +90,7 @@ function sp:parse(section)
 	  self:write(section, self.default)
    end
 end
+
 function sp.write(self, section, value)
    set_commotion()
    m.changed = true
@@ -162,7 +164,7 @@ function sid:parse(section)
    db.log("sid parse")
    local cvalue = self:cfgvalue(section)
    if not cvalue then
-	  self:write(section, self.default)
+	  self:write(section, get_sid())
    end
 end
 


### PR DESCRIPTION
Per Issue #172 

This commit adds the removal and re-creation of the serval mdp key to the loadPlugin creation process. This will force a key to be created when a user clicks the add button.

To Test: 
1) Flash a node with this branch included
2) Complete the setup wizard
3) Go to the “Basic –> Security –> Shared Mesh Keychain” menu
4) SSH into the device and type the following on the command line

```
SERVALINSTANCE_PATH=/etc/commotion/keys.d/mdp serval-client keyring list
```

5) Keep the value that is given to you. That is the current (default) keyring.
6) In the menu Click the add button
7) type the same command in again

```
SERVALINSTANCE_PATH=/etc/commotion/keys.d/mdp serval-client keyring list
```

8) The output should be different at this point. This means that it is a new keyring.
9) Click the "Save" button
10) The value for "olsrd.cfg144e54.sid=..." should match the latest key.  If it does, then you should merge this pull request as I have fulfilled my aim of fixing this bug.
