### PR TITLE
Changed default wired interface names to 'wan'

### DIFF
--- a/luasrc/model/cbi/commotion/basic_ani.lua
+++ b/luasrc/model/cbi/commotion/basic_ani.lua
@@ -30,7 +30,7 @@ if not SW.status() then
    m.on_after_save = ccbi.conf_page
 end
 
-p = m:section(NamedSection, "wired")
+p = m:section(NamedSection, "wan")
 p.anonymous = true
 
 msh = p:option(Flag, "meshed", translate("Will you be meshing with other Commotion devices over the ethernet interface?"))


### PR DESCRIPTION
This addresses opentechinstitute/commotion-router#122, and should be used in concert with the equivalent pull request opentechinstitute/commotion-router#123.

To test:
1. After flashing without retaining settings, make sure you can connect to the node via ethernet.
2. Run through setup_wizard. After it completes, make sure that the ethernet interface works as expected (gets a lease and/or gives out leases automatically).
3. Modify the settings under Additional Network Interfaces, and make sure that the settings that it's applying are used on the 'wan' config section and not 'wired.'
