### PR TITLE
updated ssid length in description

### DIFF
--- a/luasrc/model/cbi/commotion/basic_mn.lua
+++ b/luasrc/model/cbi/commotion/basic_mn.lua
@@ -65,7 +65,7 @@ end
 s.valuefooter = "cbi/full_valuefooter"
 s.template_addremove = "cbi/commotion/addMesh" --This template controls the addremove form for adding a new access point so that it has better wording.
 
-name = s:option(Value, "ssid",  translate("Mesh Network Name"), translate("Commotion networks share a network-wide name. This must be the same across all devices on the same mesh. This name cannot be greater than 15 characters."))
+name = s:option(Value, "ssid",  translate("Mesh Network Name"), translate("Commotion networks share a network-wide name. This must be the same across all devices on the same mesh. This name cannot be greater than 31 characters."))
 name.default = "commotionwireless.net"
 name.datatype = "maxlength(31)"
 function name.validate(self,val)


### PR DESCRIPTION
This just updates the language for the mesh ssid to fit with the new limit of 31 characters (currently it instructs the user that 15 is the limit).
