### PR TITLE
fix validation function for app settings expiration time field

### DIFF
--- a/luasrc/model/cbi/commotion/app_settings.lua
+++ b/luasrc/model/cbi/commotion/app_settings.lua
@@ -37,7 +37,11 @@ end
 ex_time_num = s:option(Value, "lifetime", translate("Time before applications expire"))
 function ex_time_num:validate(val)
   local dt = require "luci.cbi.datatypes"
-  return dt.uinteger(val) and tonumber(val) > 0, "expiration period must be a valid integer"
+  if dt.uinteger(val) and tonumber(val) > 0 then
+    return val
+  else
+    return nil, "expiration period must be a valid integer"
+  end
 end
 --! ex_time_num.write
 --! @brief Multiple the lifetime by the unit chosen to modify it to seconds.


### PR DESCRIPTION
fixes https://github.com/opentechinstitute/luci-commotion/issues/441.

to test, go to app settings page and click submit. Should not produce a LuCI error.