### PR TITLE
Change HTTPS header check to look for port 443 instead of missing HTTPS environment variable

### DIFF
--- a/modules/crypto.lua
+++ b/modules/crypto.lua
@@ -40,7 +40,7 @@ end
 --! @example crypto_check_https.htm
 function crypto.check_https(node, env)
    if string.match(env.REQUEST_URI, node) then
-	  if env.HTTPS ~= "on" then
+	  if env.SERVER_PORT ~= "443" then
 		 http.redirect("https://"..env.SERVER_NAME..env.REQUEST_URI)
 		 return true
 	  end


### PR DESCRIPTION
This fix should act as a workaround for the fact that uhttpd2 has removed HTTPS as a part of the server environment in Barrier Breaker. In order to test:
- Build an image using the bb-test commotion-router branch and including this fix.
- Run through the setup wizard
- Ensure that you can login to the admin interface without issue after setup is complete.

Addresses #440 
